### PR TITLE
Basic autoreply greeter functionality for lopsbot.

### DIFF
--- a/lopsbot/lopsbot.go
+++ b/lopsbot/lopsbot.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
 	irc "github.com/fluffle/goirc/client"
 	fglog "github.com/fluffle/goirc/logging/glog"
 	"github.com/golang/glog"
@@ -70,11 +70,11 @@ func main() {
 			IconEmoji: ":horse:",
 		})
 		if err != nil {
-			log.Errorf("%s", err)
+			glog.Errorf("Err %s", err)
 		}
 		resp, err := http.Post(*postURL, "application/json", bytes.NewBuffer(body))
 		if err != nil {
-			log.Errorf("%s", err)
+			glog.Errorf("%s", err)
 		}
 		resp.Body.Close()
 	})

--- a/lopsbot/lopsbot.go
+++ b/lopsbot/lopsbot.go
@@ -16,21 +16,59 @@ import (
 	"github.com/golang/glog"
 )
 
+const autoreplyPeriod = time.Hour * 24
+
+var replied map[string]time.Time
+
 var postURL = flag.String("post", "", "URL to post to")
 var channel = flag.String("channel", "", "Channel to join")
-var nick = flag.String("nick", "", "Channel to join")
+var nick = flag.String("nick", "", "Nickname for the bot")
+var autoreply = flag.String("autoreply", "", "Message to post in reply to any received message (maximum once per 24 hr per nick)")
 
-type payload struct {
-	Text      string `json:"text"`
-	IconEmoji string `json:"icon_emoji"`
+// postMessage sends the provided message as the text field of an HTTP post
+// payload to the configured postURL.
+func postMessage(message string) {
+	type payload struct {
+		Text      string `json:"text"`
+		IconEmoji string `json:"icon_emoji"`
+	}
+	body, err := json.Marshal(payload{
+		Text:      message,
+		IconEmoji: ":horse:",
+	})
+	if err != nil {
+		glog.Errorf("Err %s", err)
+	}
+	resp, err := http.Post(*postURL, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		glog.Errorf("%s", err)
+	}
+	resp.Body.Close()
+}
+
+// replyTo will send the autoreply message as a message in the monitored channel
+// directed to the specified nick if that nick hasn't received the autoreply
+// message in the autoreplyPeriod. If the nick has received the autoreply
+// message within the autoreplyPeriod nothing will be done.
+func replyTo(conn *irc.Conn, nick string) {
+	// If we've already replied and it was within the autoreplyPeriod then don't
+	// reply again
+	if repliedAt, haveReplied := replied[nick]; haveReplied && time.Since(repliedAt) < autoreplyPeriod {
+		return
+	}
+
+	replied[nick] = time.Now()
+	glog.Infof("%s> %s: %s", *channel, nick, *autoreply)
+	conn.Privmsgf(*channel, "%s: %s", nick, *autoreply)
 }
 
 func main() {
 	flag.Parse()
 	if *postURL == "" || *channel == "" || *nick == "" {
-		log.Fatalf("All flags are required")
+		log.Fatalf("The -post, -channel, and -nick flags are required")
 	}
 	fglog.Init()
+	replied = make(map[string]time.Time)
 	cfg := irc.NewConfig(*nick)
 	cfg.SSL = true
 	cfg.Server = "irc.freenode.net:7000"
@@ -65,18 +103,12 @@ func main() {
 		msg := strings.TrimPrefix(strings.Join(line.Args, " "), *channel)
 		result := fmt.Sprintf("<%s>%s\n", line.Nick, msg)
 		glog.Infof(result)
-		body, err := json.Marshal(payload{
-			Text:      result,
-			IconEmoji: ":horse:",
-		})
-		if err != nil {
-			glog.Errorf("Err %s", err)
+		postMessage(result)
+		// If there is an autoreply configured, and this message was to a channel
+		// and not a direct message to the bot, then reply to it.
+		if *autoreply != "" && line.Args[0] == *channel {
+			replyTo(conn, line.Nick)
 		}
-		resp, err := http.Post(*postURL, "application/json", bytes.NewBuffer(body))
-		if err != nil {
-			glog.Errorf("%s", err)
-		}
-		resp.Body.Close()
 	})
 	err := c.Connect()
 	if err != nil {


### PR DESCRIPTION
This allows configuring an `-autoreply` message that is sent in-channel at most once per autoreplyPeriod (24 hrs) per nick in response to things said in channel. This can be used (for e.g.) to close an IRC channel by sending an informative message to anyone that tries to use the channel. 

Along the way I removed a stale binary I believe was checked in by mistake (a59e65a) and removed an unnecessary dependency on CFSSL for logging (b92280c)