### PR TITLE
caa-lookups: add support for TXT and AAAA queries

### DIFF
--- a/caa-lookups/lookups.go
+++ b/caa-lookups/lookups.go
@@ -27,7 +27,8 @@ var spawnRate = flag.Int("spawnRate", 100, "Rate of spawning goroutines")
 var spawnInterval = flag.Duration("spawnInterval", 1*time.Minute, "Interval on which to spawn goroutines")
 var checkCAA = flag.Bool("checkCAA", false, "Whether to check CAA records")
 var checkA = flag.Bool("checkA", false, "Whether to check A records")
-var checkDNAME = flag.Bool("checkDNAME", false, "Whether to check A records")
+var checkDNAME = flag.Bool("checkDNAME", false, "Whether to check DNAME records")
+var checkTXT = flag.Bool("checkTXT", false, "Whether to check TXT records")
 var c *dns.Client
 
 var (
@@ -110,6 +111,12 @@ func tryAll(name string) error {
 	if *checkA {
 		err = query(name, dns.TypeA)
 		if err != nil {
+			return err
+		}
+	}
+	if *checkTXT {
+		target := fmt.Sprintf("_acme-challenge.%s", name)
+		if err := query(target, dns.TypeTXT); err != nil {
 			return err
 		}
 	}

--- a/caa-lookups/lookups.go
+++ b/caa-lookups/lookups.go
@@ -27,6 +27,7 @@ var spawnRate = flag.Int("spawnRate", 100, "Rate of spawning goroutines")
 var spawnInterval = flag.Duration("spawnInterval", 1*time.Minute, "Interval on which to spawn goroutines")
 var checkCAA = flag.Bool("checkCAA", false, "Whether to check CAA records")
 var checkA = flag.Bool("checkA", false, "Whether to check A records")
+var checkAAAA = flag.Bool("checkAAAA", false, "Whether to check AAAA records")
 var checkDNAME = flag.Bool("checkDNAME", false, "Whether to check DNAME records")
 var checkTXT = flag.Bool("checkTXT", false, "Whether to check TXT records")
 var c *dns.Client
@@ -111,6 +112,11 @@ func tryAll(name string) error {
 	if *checkA {
 		err = query(name, dns.TypeA)
 		if err != nil {
+			return err
+		}
+	}
+	if *checkAAAA {
+		if err := query(name, dns.TypeAAAA); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
(Also fixed a typo in the `checkDNAME` flag help string)